### PR TITLE
Ensure disabled tasks return full tuple & fix public‐dataset filter

### DIFF
--- a/src/xares/run.py
+++ b/src/xares/run.py
@@ -28,7 +28,7 @@ def worker(
     config = attr_from_py_path(task_py, endswith="_config")(encoder)
     if config.disabled:
         logger.warning(f"Task {config.name} is disabled, skipping")
-        return config.formal_name, (0, 0), (0, 0)
+        return config.formal_name, (0, 0), (0, 0), config.private
     task = XaresTask(config=config)
 
     # Run the task

--- a/src/xares/run.py
+++ b/src/xares/run.py
@@ -183,7 +183,7 @@ def main(args):
         print(f"\nResults:\n{df.to_string(index=False)}")
 
         avg_mlp_all, avg_knn_all = weighted_average({k: v[1:-1] for k, v in return_dict.items()})
-        avg_mlp_public, avg_knn_public = weighted_average({k: v[1:-1] for k, v in return_dict.items() if v[-1] == True})
+        avg_mlp_public, avg_knn_public = weighted_average({k: v[1:-1] for k, v in return_dict.items() if v[-1] == False})
 
         print("\nWeighted Average MLP Score for All Datasets:", avg_mlp_all)
         print("Weighted Average KNN Score for All Datasets:", avg_knn_all)


### PR DESCRIPTION
This PR addresses two related bugs in task scoring:

1. **Disabled‐task return shape**  
   - Previously, when `config.disabled == True`, `worker()` returned a 3-tuple  
     `(formal_name, (0,0), (0,0))`. Downstream code always expected a 4-tuple  
     `(formal_name, mlp_score, knn_score, private_flag)`, causing an index-out-
     of-range error when building the DataFrame.
   - **Fix:** Return `(formal_name, (0,0), (0,0), config.private)` so the shape is  
     consistent in all cases.

2. **Public‐dataset filter logic**  
   - The “public” weighted‐average was filtering on `v[-1] == True`, but `v[-1]`  
     is actually the `private` flag. That made “public” averages include only private tasks.
   - **Fix:** Change the condition to `if v[-1] == False` so that only non-private (public)  
     tasks are aggregated.

Both fixes are split into two commits for clarity. All existing tasks (and any new ones) should now pass without index errors, and the “public” averages reflect the intended data.
