### PR TITLE
Force integer tensors to int64 in cast_to_tensor to fix Windows int32 issue

### DIFF
--- a/src/xares/trainer.py
+++ b/src/xares/trainer.py
@@ -32,7 +32,7 @@ def masked_mean(x, x_length, dim: int = -1):
 
 def cast_to_tensor(y: Iterable):
     y = y if isinstance(y, torch.Tensor) else torch.tensor(y)
-    return y.float() if y.is_floating_point() else y
+    return y.float() if y.is_floating_point() else y.long()
 
 
 def pad_or_trim(tensor, target_size):


### PR DESCRIPTION
## What
 
On Windows, numpy’s `long` is 32 bits by default (cf [this](https://stackoverflow.com/a/36279321)).
When we call:

```python
def cast_to_tensor(y: Iterable):
    y = y if isinstance(y, torch.Tensor) else torch.tensor(y)
    return y.float() if y.is_floating_point() else y
```

the non-float branch ends up with a 32-bit tensor, but our MLP losses expect int64 targets, causing a dtype error at training time.

## Fix
Change the integer fallback to use .long() so it always produces a 64-bit tensor:

```python
def cast_to_tensor(y: Iterable):
    y = y if isinstance(y, torch.Tensor) else torch.tensor(y)
-   return y.float() if y.is_floating_point() else y
+   return y.float() if y.is_floating_point() else y.long()
```

## Why

Guarantees torch.int64 for integer inputs on all platforms.

Prevents training failures on Windows without affecting Linux/macOS.

## Testing

Tried doing multiple tasks on both Windows and Linux without issue.
